### PR TITLE
remove Push to GitHub button

### DIFF
--- a/app/launch/src/components/GenerateButtons/GenerateButtons.js
+++ b/app/launch/src/components/GenerateButtons/GenerateButtons.js
@@ -57,32 +57,6 @@ const GenerateButtons = ({
         </Button>
       }
     >
-      <TooltipWrapper tooltip={messages.tooltips.createRepo}>
-        <a
-          href={gitHubCreateHref}
-          disabled={disabled}
-          waves="light"
-          className={theme}
-          style={{
-            alignItems: 'center',
-            display: 'flex',
-          }}
-          onClick={cloneProject}
-        >
-          <GitHubIcon
-            style={{
-              marginLeft: '4px',
-              marginRight: '28px',
-            }}
-            fontSize="small"
-            className="action-button-icon"
-          >
-            clone_app
-          </GitHubIcon>
-          Push to GitHub
-        </a>
-      </TooltipWrapper>
-
       <TooltipWrapper tooltip={messages.tooltips.generate}>
         <a
           role="button"

--- a/app/launch/src/components/GenerateButtons/GenerateButtons.js
+++ b/app/launch/src/components/GenerateButtons/GenerateButtons.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import GitHubIcon from '@material-ui/icons/GitHub'
 import Button from 'react-materialize/lib/Button'
 import Dropdown from 'react-materialize/lib/Dropdown'
 import Icon from 'react-materialize/lib/Icon'
@@ -8,7 +7,6 @@ import messages from '../../constants/messages.json'
 
 import { GENERATE_SHORTCUT } from '../../constants/shortcuts'
 import useKeyboardShortcuts from '../../hooks/useKeyboardShortcuts'
-import { useGitHubShareLink, useStarterForm } from '../../state/store'
 import OtherCommands from '../OtherCommands'
 import { TooltipWrapper } from '../TooltipButton'
 
@@ -20,7 +18,6 @@ const GenerateButtons = ({
   baseUrl,
 }) => {
   const createPayload = useStarterForm()
-  const gitHubCreateHref = useGitHubShareLink()
 
   useKeyboardShortcuts(GENERATE_SHORTCUT.keys, generateProject, disabled)
 

--- a/app/launch/src/components/GenerateButtons/GenerateButtons.js
+++ b/app/launch/src/components/GenerateButtons/GenerateButtons.js
@@ -7,6 +7,7 @@ import messages from '../../constants/messages.json'
 
 import { GENERATE_SHORTCUT } from '../../constants/shortcuts'
 import useKeyboardShortcuts from '../../hooks/useKeyboardShortcuts'
+import { useStarterForm } from '../../state/store'
 import OtherCommands from '../OtherCommands'
 import { TooltipWrapper } from '../TooltipButton'
 


### PR DESCRIPTION
This feature has been removed from https://micronaut.io/launch and https://start.spring.io/.  This PR updates Grails Forge to do the same.  

This feature required substantial access to push to GitHub.  

<img width="1201" height="1740" alt="image" src="https://github.com/user-attachments/assets/8aacea41-41a4-4300-83dd-0953b5648985" />
